### PR TITLE
Displaying dollar sign optional; allowing cents is optional

### DIFF
--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -2,7 +2,10 @@ import React, { CSSProperties, FC, KeyboardEvent, useCallback } from 'react';
 
 interface Props {
   className?: string;
+  id?: string;
   max?: number;
+  cents?: boolean;
+  includeSign?: boolean;
   onValueChange: (value: number) => void;
   style?: CSSProperties;
   value: number;
@@ -13,12 +16,17 @@ const VALID_NEXT = /^[0-9]{1}$/;
 const DELETE_KEY_CODE = 8;
 
 const CurrencyInput: FC<Props> = ({
-  className = '',
-  max = Number.MAX_SAFE_INTEGER,
+  className = undefined,
+  id = undefined,
+  max = Number.MAX_SAFE_INTEGER / 100,
+  cents = true,
+  includeSign = true,
   onValueChange,
   style = {},
   value,
 }) => {
+  max = cents ? max * 100 : max;
+  value = cents ? Math.trunc(value * 100) : value;
   const valueAbsTrunc = Math.trunc(Math.abs(value));
   if (value !== valueAbsTrunc || !Number.isFinite(value) || Number.isNaN(value)) {
     throw new Error(`invalid value property`);
@@ -44,21 +52,26 @@ const CurrencyInput: FC<Props> = ({
       if (nextValue > max) {
         return;
       }
-      onValueChange(nextValue);
+      onValueChange(cents ? nextValue / 100 : nextValue);
     },
     [max, onValueChange, value]
   );
   const handleChange = useCallback(() => {
     // DUMMY TO AVOID REACT WARNING
   }, []);
-  const valueDisplay = (value / 100).toLocaleString('en-US', {
+
+  let valueDisplay = (cents ? value / 100 : value).toLocaleString('en-US', {
     style: 'currency',
     currency: 'USD',
   });
 
+  // trim the dollar sign off if unwanted
+  valueDisplay = includeSign ? valueDisplay : valueDisplay.slice(1);
+
   return (
     <input
       className={className}
+      id={id}
       inputMode="numeric"
       onChange={handleChange}
       onKeyDown={handleKeyDown}

--- a/src/components/CurrencyInput.tsx
+++ b/src/components/CurrencyInput.tsx
@@ -63,6 +63,8 @@ const CurrencyInput: FC<Props> = ({
   let valueDisplay = (cents ? value / 100 : value).toLocaleString('en-US', {
     style: 'currency',
     currency: 'USD',
+    minimumFractionDigits: cents ? undefined : 0,
+    maximumFractionDigits: cents ? undefined : 0
   });
 
   // trim the dollar sign off if unwanted


### PR DESCRIPTION
- Fixed an issue where the value passed to the component was set to the amount the user specified times 100. 
- Added a "cents" property accepting a boolean: true to allow the user to include cents in their input (default), false to only allow whole dollar amounts.
- Added a "includeSign" property accepting a boolean: true to show the dollar sign in the input's display, false otherwise